### PR TITLE
Do not override the Ethereum RPC endpoint.

### DIFF
--- a/src/chains/index.js
+++ b/src/chains/index.js
@@ -45,12 +45,6 @@ function getDefaultChainList() {
       }
     }
 
-    // Final manual overrides :
-    // Ethereum: Cloudflare seems to be flaky lately, use publicnode.com
-    if(originalChain.chainId == 1) {
-      defaultRpcs = ["https://ethereum.publicnode.com"]
-    }
-
     let newChain = {
       id: originalChain.chainId,
       name: originalChain.name,


### PR DESCRIPTION
Now that web3protocol supports multiple RPC endpoints, this should no longer be necessary.